### PR TITLE
updated test data and CQL to correspond to member id slicing

### DIFF
--- a/input/cql/MBODAInitialExpressions.cql
+++ b/input/cql/MBODAInitialExpressions.cql
@@ -12,16 +12,24 @@ include USCoreElements version '0.1.0' called UCE
 include CumulativeMedicationDuration version '3.1.000' called CMD
 
 codesystem "LOINC": 'http://loinc.org'
+codesystem "Identifier Type": 'http://terminology.hl7.org/CodeSystem/v2-0203'
 code "Body surface area": '8277-6' from "LOINC" display 'Intensive care unit'
+code "Member Number": 'MB' from "Identifier Type"
 
 context Patient
 
 define "Member ID":
-  singleton from (
-    [FHIR.Coverage] C
-    where EndsWith(C.subscriber.reference, Patient.id)
-    return C.subscriberId.value
-  )
+  singleton from
+    (
+      ("FHIR Coverage".identifier I
+    return {value: I.value.value, type: I.type.coding.code}
+    ) valuesByTypes
+    where "Member Number".code in valuesByTypes.type
+    return valuesByTypes.value
+    )
+
+    define "FHIR Coverage":
+ [FHIR.Coverage] C where EndsWith(C.beneficiary.reference, Patient.id)
 
 define "Patient Name":
   UCE."Name - First Middle(s) Last"

--- a/input/cql/MBODAInitialExpressions.cql
+++ b/input/cql/MBODAInitialExpressions.cql
@@ -21,15 +21,17 @@ context Patient
 define "Member ID":
   singleton from
     (
-      ("FHIR Coverage".identifier I
-    return {value: I.value.value, type: I.type.coding.code}
-    ) valuesByTypes
+      (
+        (
+          ([FHIR.Coverage] C 
+              where EndsWith(C.beneficiary.reference, Patient.id))
+          .identifier) I
+        return {value: I.value.value, type: I.type.coding.code}
+      ) valuesByTypes
     where "Member Number".code in valuesByTypes.type
     return valuesByTypes.value
     )
 
-    define "FHIR Coverage":
- [FHIR.Coverage] C where EndsWith(C.beneficiary.reference, Patient.id)
 
 define "Patient Name":
   UCE."Name - First Middle(s) Last"

--- a/input/tests/library/MBODAInitialExpressions/example-continued-therapy/Coverage-example.json
+++ b/input/tests/library/MBODAInitialExpressions/example-continued-therapy/Coverage-example.json
@@ -12,8 +12,15 @@
   },
   "identifier": [
     {
-      "system": "http://benefitsinc.com/certificate",
-      "value": "12345"
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MB"
+          }
+        ]
+      },
+      "value": "member-id-from-identifier-slice-example-continued-therapy-patient"
     }
   ],
   "status": "active",

--- a/input/tests/library/MBODAInitialExpressions/example-new-therapy/Coverage-example.json
+++ b/input/tests/library/MBODAInitialExpressions/example-new-therapy/Coverage-example.json
@@ -14,6 +14,17 @@
     {
       "system": "http://benefitsinc.com/certificate",
       "value": "12345"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MB"
+          }
+        ]
+      },
+      "value": "member-id-from-identifier-slice-example-new-therapy-patient"
     }
   ],
   "status": "active",

--- a/input/tests/library/MBODAInitialExpressions/example/Coverage-example.json
+++ b/input/tests/library/MBODAInitialExpressions/example/Coverage-example.json
@@ -12,8 +12,15 @@
   },
   "identifier": [
     {
-      "system": "http://benefitsinc.com/certificate",
-      "value": "12345"
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MB"
+          }
+        ]
+      },
+      "value": "member-id-from-identifier-slice-example-patient"
     }
   ],
   "status": "active",


### PR DESCRIPTION
https://hl7.org/fhir/us/core/StructureDefinition-us-core-coverage.html

Remaining Questions:
* Should FHIR.NamingSystemIdentifierType already work?
* is there a cleaner way to directly retrieve FHIR.Coverage filtered by beneficiary patient reference within the Member ID definition?